### PR TITLE
remove dataloader multiprocessing for non-linux devices

### DIFF
--- a/trident/wsi_objects/WSI.py
+++ b/trident/wsi_objects/WSI.py
@@ -3,6 +3,7 @@ import numpy as np
 import openslide
 from PIL import Image
 import os 
+import sys
 import warnings
 import torch 
 from typing import List, Tuple, Optional
@@ -466,8 +467,15 @@ class OpenSlideWSI:
         precision = segmentation_model.precision
         device = segmentation_model.device
         eval_transforms = segmentation_model.eval_transforms
+
         dataset = WSIPatcherDataset(patcher, eval_transforms)
-        dataloader = DataLoader(dataset, batch_size=batch_size, num_workers=get_num_workers(batch_size, max_workers=self.max_workers), pin_memory=True)
+        if sys.platform == "linux":
+            dataloader = DataLoader(dataset, 
+                                    batch_size=batch_size, 
+                                    num_workers=get_num_workers(batch_size, max_workers=self.max_workers), 
+                                    pin_memory=True)  
+        else:
+            dataloader = DataLoader(dataset, batch_size=batch_size, pin_memory=True)
 
         mpp_reduction_factor = self.mpp / destination_mpp
         width, height = self.get_dimensions()
@@ -830,8 +838,15 @@ class OpenSlideWSI:
             coords_only=False,
             pil=True
         )
+
         dataset = WSIPatcherDataset(patcher, patch_transforms)
-        dataloader = DataLoader(dataset, batch_size=batch_limit, num_workers=get_num_workers(batch_limit, max_workers=self.max_workers), pin_memory=True)
+        if sys.platform == "linux":
+            dataloader = DataLoader(dataset, 
+                                    batch_size=batch_limit, 
+                                    num_workers=get_num_workers(batch_limit, max_workers=self.max_workers), 
+                                    pin_memory=True)  
+        else:
+            dataloader = DataLoader(dataset, batch_size=batch_limit, pin_memory=True)
 
         features = []
         for imgs, _ in dataloader:


### PR DESCRIPTION
This is a temporary work around for windows or macOS devices.

https://github.com/pytorch/pytorch/issues/70344
https://stackoverflow.com/questions/64095876/multiprocessing-fork-vs-spawn

Adding `export OBJC_DISABLE_INITIALIZE_FORK_SAFETY=YES` does not solve the issue either (Macbook Pro, M4 Pro, MacOS: Sequoia 15.1.1).